### PR TITLE
Nz mk estimate next purchase date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .env.test.local
 .env.production.local
 .eslintcache
+.firebaserc
 
 npm-debug.log*
 yarn-debug.log*

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,7 +2,7 @@
 
 Add yourself as a contributor to this project as a Markdown link that links your name to your GitHub profile and shows your favorite emoji, as in the following example:
 
-    - [Dione Developer](https://github.com/DioneDeveloper) 💅
+    - ✨ [Dione Developer](https://github.com/DioneDeveloper) 💅
 
 ## Cohort Participants
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,9 +74,17 @@ export function App() {
 					}
 				/>
 
-				<Route path="/list" element={<List data={data} loading={loading} listToken={listToken}/>} />
+				<Route
+					path="/list"
+					element={<List data={data} loading={loading} listToken={listToken} />}
+				/>
 
-				<Route path="/add-item" element={<AddItem listToken={listToken} />} />
+				<Route
+					path="/add-item"
+					element={
+						<AddItem listToken={listToken} itemList={data} setData={setData} />
+					}
+				/>
 			</Route>
 		</Routes>
 	);

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -85,31 +85,28 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 		isChecked: false,
 		name: itemName,
 		totalPurchases: 0,
-		previousEstimate: daysUntilNextPurchase,
+		previousEstimate: parseInt(daysUntilNextPurchase),
 	});
 }
 
 export async function updateItem(listId, itemData) {
-	/**
-	 * TODO: Fill this out so that it uses the correct Firestore function
-	 * to update an existing item! You'll need to figure out what arguments
-	 * this function must accept!
-	 */
 	const itemRef = doc(db, listId, itemData.id);
-	console.log('in updateItem');
-	let dayDiff;
-	if (itemData.dateLastPurchased) {
-		dayDiff = getDaysBetweenDates(itemData.dateLastPurchased);
-	} else {
-		dayDiff = getDaysBetweenDates(itemData.dateCreated);
-	}
+	let daysSinceLastTransaction;
+	itemData.dateLastPurchased
+		? (daysSinceLastTransaction = getDaysBetweenDates(
+				itemData.dateLastPurchased,
+		  ))
+		: (daysSinceLastTransaction = getDaysBetweenDates(itemData.dateCreated));
 
+	// this line with "let previousEstimate = parseInt .." can be removed if the database is reset. This line is required for converting old time frame entriies to numbers.
 	let previousEstimate = parseInt(itemData.previousEstimate);
+
 	let newTimeEstimate = calculateEstimate(
 		previousEstimate,
-		dayDiff,
+		daysSinceLastTransaction,
 		itemData.totalPurchases,
 	);
+
 	await updateDoc(itemRef, {
 		totalPurchases: itemData.totalPurchases,
 		isChecked: itemData.isChecked,

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -84,11 +84,7 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 		isChecked: false,
 		name: itemName,
 		totalPurchases: 0,
-<<<<<<< HEAD
 		previousEstimate: parseInt(daysUntilNextPurchase),
-=======
-		previousEstimate: daysUntilNextPurchase,
->>>>>>> b6a6a8d (removed redundant itemData, added new field with previousEstimate to be saved to Firestore when an item is added to the list)
 	});
 }
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -13,7 +13,6 @@ import {
 } from 'firebase/firestore';
 
 import { getDaysBetweenDates, getFutureDate } from '../utils';
-// import { getFutureDate, getDaysBetweenDates } from '../utils';
 
 const firebaseConfig = {
 	apiKey: 'AIzaSyAKhXStVolfPKwMsQCo7KiSePpC_zcJY-4',
@@ -85,7 +84,11 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 		isChecked: false,
 		name: itemName,
 		totalPurchases: 0,
+<<<<<<< HEAD
 		previousEstimate: parseInt(daysUntilNextPurchase),
+=======
+		previousEstimate: daysUntilNextPurchase,
+>>>>>>> b6a6a8d (removed redundant itemData, added new field with previousEstimate to be saved to Firestore when an item is added to the list)
 	});
 }
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -96,28 +96,27 @@ export async function updateItem(listId, itemData) {
 	 * this function must accept!
 	 */
 	const itemRef = doc(db, listId, itemData.id);
-
+	console.log('in updateItem');
+	let dayDiff;
 	if (itemData.dateLastPurchased) {
-		let dayDiff = getDaysBetweenDates(itemData);
-		// console.log('dayDiff', dayDiff);
-		let previousEstimate = parseInt(itemData.previousEstimate);
-		let estimate = calculateEstimate(
-			previousEstimate,
-			dayDiff,
-			itemData.totalPurchases,
-		);
-		// console.log('estimate', estimate);
-		await updateDoc(itemRef, {
-			totalPurchases: itemData.totalPurchases,
-			isChecked: itemData.isChecked,
-			dateLastPurchased: new Date(),
-			dateNextPurchased: calculateEstimate(
-				previousEstimate,
-				dayDiff,
-				itemData.totalPurchases,
-			),
-		});
+		dayDiff = getDaysBetweenDates(itemData.dateLastPurchased);
+	} else {
+		dayDiff = getDaysBetweenDates(itemData.dateCreated);
 	}
+
+	let previousEstimate = parseInt(itemData.previousEstimate);
+	let newTimeEstimate = calculateEstimate(
+		previousEstimate,
+		dayDiff,
+		itemData.totalPurchases,
+	);
+	await updateDoc(itemRef, {
+		totalPurchases: itemData.totalPurchases,
+		isChecked: itemData.isChecked,
+		dateLastPurchased: new Date(),
+		dateNextPurchased: getFutureDate(newTimeEstimate),
+		previousEstimate: newTimeEstimate,
+	});
 }
 
 //previousEstimate from DB, getDaysBetweenDates for daysSinceLastTransactionUpdate, totalPurchases from DB

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -1,3 +1,4 @@
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import { initializeApp } from 'firebase/app';
 
 import {
@@ -11,7 +12,7 @@ import {
 	doc,
 } from 'firebase/firestore';
 
-import { getFutureDate } from '../utils';
+import { getFutureDate, getDaysBetweenDates } from '../utils';
 
 const firebaseConfig = {
 	apiKey: 'AIzaSyAKhXStVolfPKwMsQCo7KiSePpC_zcJY-4',
@@ -83,6 +84,7 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 		isChecked: false,
 		name: itemName,
 		totalPurchases: 0,
+		//get previousEstimate: 7/14/30 from the input and add it when the item is added
 	});
 }
 
@@ -97,6 +99,8 @@ export async function updateItem(listId, itemData) {
 		totalPurchases: itemData.totalPurchases,
 		isChecked: itemData.isChecked,
 		dateLastPurchased: new Date(),
+		dateNextPurchased: calculateEstimate(),
+		//previousEstimate from DB, getDaysBetweenDates for daysSinceLastTransactionUpdate, totalPurchases from DB
 	});
 }
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -85,7 +85,7 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 		isChecked: false,
 		name: itemName,
 		totalPurchases: 0,
-		previousEstimate: daysUntilNextPurchase,
+		// previousEstimate: daysUntilNextPurchase,
 	});
 }
 
@@ -100,7 +100,7 @@ export async function updateItem(listId, itemData) {
 		totalPurchases: itemData.totalPurchases,
 		isChecked: itemData.isChecked,
 		dateLastPurchased: new Date(),
-		dateNextPurchased: calculateEstimate(),
+		// dateNextPurchased: calculateEstimate(),
 		//previousEstimate from DB, getDaysBetweenDates for daysSinceLastTransactionUpdate, totalPurchases from DB
 	});
 }

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -12,7 +12,8 @@ import {
 	doc,
 } from 'firebase/firestore';
 
-import { getFutureDate, getDaysBetweenDates } from '../utils';
+import { getFutureDate } from '../utils';
+// import { getFutureDate, getDaysBetweenDates } from '../utils';
 
 const firebaseConfig = {
 	apiKey: 'AIzaSyAKhXStVolfPKwMsQCo7KiSePpC_zcJY-4',
@@ -84,7 +85,7 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 		isChecked: false,
 		name: itemName,
 		totalPurchases: 0,
-		//get previousEstimate: 7/14/30 from the input and add it when the item is added
+		previousEstimate: daysUntilNextPurchase,
 	});
 }
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -111,11 +111,11 @@ export async function updateItem(listId, itemData) {
 			totalPurchases: itemData.totalPurchases,
 			isChecked: itemData.isChecked,
 			dateLastPurchased: new Date(),
-			dateNextPurchased: calculateEstimate({
-				previousEstimate: parseInt(itemData.previousEstimate),
-				daysSinceLastTransaction: dayDiff,
-				totalPurchases: itemData.totalPurchases,
-			}),
+			dateNextPurchased: calculateEstimate(
+				previousEstimate,
+				dayDiff,
+				itemData.totalPurchases,
+			),
 		});
 	}
 }

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -11,7 +11,7 @@ export function ListItem({ item, listToken }) {
 		? item.dateLastPurchased.seconds * 1000
 		: null;
 	let timeElapsed = currentTimeInMilliseconds - dateLastPurchasedInMilliseconds;
-
+	const [boxChecked, setBoxChecked] = useState(false);
 	const [isPurchased, setIsPurchased] = useState(item.isChecked);
 
 	const handlePurchaseItem = async () => {
@@ -19,20 +19,34 @@ export function ListItem({ item, listToken }) {
 			if (item.isChecked === false) {
 				item.totalPurchases++;
 				item.isChecked = true;
+				setBoxChecked(true);
 				await updateItem(listToken, item);
 			} else {
 				item.totalPurchases--;
 				item.isChecked = false;
+				setBoxChecked(false);
 				await updateItem(listToken, item);
 			}
 		} catch (error) {
 			console.log('error', error);
 		}
 	};
-	// getDaysBetweenDates of lastPurchasedDate and now
 
 	useEffect(() => {
-		if (timeElapsed > one_day_in_ms && item.isChecked === true) {
+		console.log('isPurchased', isPurchased);
+		console.log('isChecked', item.isChecked);
+		if (
+			timeElapsed > one_day_in_ms &&
+			isPurchased === true &&
+			boxChecked === true
+		) {
+			item.isChecked = isPurchased;
+			updateItem(listToken, item);
+		} else if (
+			timeElapsed > one_day_in_ms &&
+			item.isChecked === true &&
+			boxChecked === false
+		) {
 			item.isChecked = false;
 			updateItem(listToken, item);
 		}

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,6 +1,7 @@
 import './ListItem.css';
 import { useState, useEffect } from 'react';
 import { updateItem } from '../api';
+import { getDaysBetweenDates } from '../utils';
 const one_day_in_ms = 24 * 60 * 60 * 1000;
 // const one_day_in_ms = 60 * 2 * 1000; // 120 seconds for testing the reset timeframe
 
@@ -29,6 +30,7 @@ export function ListItem({ item, listToken }) {
 			console.log('error', error);
 		}
 	};
+	// getDaysBetweenDates of lastPurchasedDate and now
 
 	useEffect(() => {
 		if (timeElapsed > one_day_in_ms) {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,7 +1,6 @@
 import './ListItem.css';
 import { useState, useEffect } from 'react';
 import { updateItem } from '../api';
-import { getDaysBetweenDates } from '../utils';
 const one_day_in_ms = 24 * 60 * 60 * 1000;
 // const one_day_in_ms = 60 * 2 * 1000; // 120 seconds for testing the reset timeframe
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -33,8 +33,6 @@ export function ListItem({ item, listToken }) {
 	};
 
 	useEffect(() => {
-		console.log('isPurchased', isPurchased);
-		console.log('isChecked', item.isChecked);
 		if (
 			timeElapsed > one_day_in_ms &&
 			isPurchased === true &&

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -32,7 +32,7 @@ export function ListItem({ item, listToken }) {
 	// getDaysBetweenDates of lastPurchasedDate and now
 
 	useEffect(() => {
-		if (timeElapsed > one_day_in_ms) {
+		if (timeElapsed > one_day_in_ms && item.isChecked === true) {
 			item.isChecked = false;
 			updateItem(listToken, item);
 		}

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -11,10 +11,10 @@ export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
 
-export function getDaysBetweenDates({ dateLastPurchased }) {
+export function getDaysBetweenDates(lastTransaction) {
 	let today = new Date();
 	// get both dates in milliseconds
-	let timeDifference = today.getTime() - dateLastPurchased.toMillis();
+	let timeDifference = today.getTime() - lastTransaction.toMillis();
 	// change milliseconds into days, rounding up
 	let dayDifference = Math.ceil(timeDifference / ONE_DAY_IN_MILLISECONDS);
 	return dayDifference;

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,10 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+
+export function getDaysBetweenDates() {
+	return;
+}
+
+// getDaysBetweenDates (LastPurchasedDate, Date.now()) {
+//  return today(Date.now()) - LastPurchasedDate }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -11,9 +11,11 @@ export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
 
-export function getDaysBetweenDates() {
-	return;
+export function getDaysBetweenDates({ dateLastPurchased }) {
+	let today = new Date();
+	// get both dates in milliseconds
+	let timeDifference = today.getTime() - dateLastPurchased.toMillis();
+	// change milliseconds into days, rounding up
+	let dayDifference = Math.ceil(timeDifference / ONE_DAY_IN_MILLISECONDS);
+	return dayDifference;
 }
-
-// getDaysBetweenDates (LastPurchasedDate, Date.now()) {
-//  return today(Date.now()) - LastPurchasedDate }

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -1,20 +1,32 @@
 import { useState } from 'react';
 import { addItem } from '../api/firebase';
 
-export function AddItem({ listToken }) {
+export function AddItem({ listToken, itemList, setData }) {
 	const [daysUntilNextPurchase, setTimeFrame] = useState('7');
 	const [itemName, setItem] = useState('');
 	const [error, setError] = useState(false);
+	const [duplicateError, setDuplicateError] = useState(false);
 	const [success, setSuccess] = useState(false);
+	// check for duplicate item in list
+	const isDuplicate = (itemList) =>
+		itemList.name.toLowerCase().replace(/ /g, '') ===
+		itemName.toLowerCase().replace(/ /g, '');
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
+		const duplicateItem = itemList.some(isDuplicate);
 		try {
-			await addItem(listToken, { itemName, daysUntilNextPurchase });
-			setError(false);
-			setSuccess(true);
-			setItem('');
-			setTimeFrame('7');
+			if (!duplicateItem) {
+				setData({ itemName, daysUntilNextPurchase });
+				addItem(listToken, { itemName, daysUntilNextPurchase });
+				setError(false);
+				setSuccess(true);
+				setItem('');
+				setTimeFrame('7');
+			} else {
+				setDuplicateError(true);
+				setSuccess(false);
+			}
 		} catch (err) {
 			console.log(err.message);
 			setError(true);
@@ -23,7 +35,7 @@ export function AddItem({ listToken }) {
 
 	const handleName = (e) => {
 		setSuccess(false);
-
+		setDuplicateError(false);
 		setItem(e.target.value);
 	};
 
@@ -89,6 +101,11 @@ export function AddItem({ listToken }) {
 					</fieldset>
 				</div>
 				{error && <p>The item was not added</p>}
+				{duplicateError && (
+					<p>
+						The item already exists on your list! Try adding a different item.
+					</p>
+				)}
 				{success && <p>The item has been added</p>}
 
 				<div className="button">

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -4,13 +4,11 @@ import { addItem } from '../api/firebase';
 export function AddItem({ listToken }) {
 	const [daysUntilNextPurchase, setTimeFrame] = useState('7');
 	const [itemName, setItem] = useState('');
-	const [itemData, setData] = useState({});
 	const [error, setError] = useState(false);
 	const [success, setSuccess] = useState(false);
 
 	const handleSubmit = async (e) => {
 		e.preventDefault();
-		setData({ itemName, daysUntilNextPurchase });
 		try {
 			await addItem(listToken, { itemName, daysUntilNextPurchase });
 			setError(false);

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -62,7 +62,7 @@ export function AddItem({ listToken }) {
 								id="soon"
 								onChange={handleTime}
 							/>
-							Soon (7 days)
+							Soon
 						</label>
 
 						<label htmlFor="kind-of-soon">
@@ -73,7 +73,7 @@ export function AddItem({ listToken }) {
 								value="14"
 								onChange={handleTime}
 							/>
-							Kind of Soon (14 days)
+							Kind of Soon
 						</label>
 
 						<label htmlFor="not-soon">
@@ -84,7 +84,7 @@ export function AddItem({ listToken }) {
 								value="30"
 								onChange={handleTime}
 							/>
-							Not Soon (30 days)
+							Not Soon
 						</label>
 					</fieldset>
 				</div>

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -74,7 +74,7 @@ export function AddItem({ listToken, itemList, setData }) {
 								id="soon"
 								onChange={handleTime}
 							/>
-							Soon
+							Soon (7 days)
 						</label>
 
 						<label htmlFor="kind-of-soon">
@@ -85,7 +85,7 @@ export function AddItem({ listToken, itemList, setData }) {
 								value="14"
 								onChange={handleTime}
 							/>
-							Kind of Soon
+							Kind of Soon (14 days)
 						</label>
 
 						<label htmlFor="not-soon">
@@ -96,7 +96,7 @@ export function AddItem({ listToken, itemList, setData }) {
 								value="30"
 								onChange={handleTime}
 							/>
-							Not Soon
+							Not Soon (30 days)
 						</label>
 					</fieldset>
 				</div>

--- a/src/views/AddItem.jsx
+++ b/src/views/AddItem.jsx
@@ -62,7 +62,7 @@ export function AddItem({ listToken }) {
 								id="soon"
 								onChange={handleTime}
 							/>
-							Soon
+							Soon (7 days)
 						</label>
 
 						<label htmlFor="kind-of-soon">
@@ -73,7 +73,7 @@ export function AddItem({ listToken }) {
 								value="14"
 								onChange={handleTime}
 							/>
-							Kind of Soon
+							Kind of Soon (14 days)
 						</label>
 
 						<label htmlFor="not-soon">
@@ -84,7 +84,7 @@ export function AddItem({ listToken }) {
 								value="30"
 								onChange={handleTime}
 							/>
-							Not Soon
+							Not Soon (30 days)
 						</label>
 					</fieldset>
 				</div>


### PR DESCRIPTION
## Description

In order to advise users about when to purchase things, the app needs to be able to calculate that guess and store it a future date. This issue tackles estimating the next purchase date according to the difference between the last purchase date and the current purchase date. We started by understanding the `calculateEstimate` function that was provided in the` collab-lab utils` `npm` folder, which required three arguments: `previousEstimate`, `daysSinceLastPurchase`, and `totalPurchases`. The `daysSinceLastPurchase` was calculated using a generic function we wrote called `getDaysBetweenDates` in `utils/dates` that takes two JavaScript Dates and return the number of days that have passed between them. We approached this issue by pseudocoding what we know this function's parameters would be, and looked into how firebase deals with JavaScript dates. After that, we worked in `api/firebase` in the `updateItem` function to add a dynamic `previousEstimate` value and `dateNextPurchased` which value is defined according to whether a `dateLastPurchased` value is null or not. This `updateItem` function is triggered by a user clicking on a checkbox to indicate a purchase action, which should update firebase accordingly to estimate the next purchase date.

We also fixed two bugs inherited from the previous week:
1. all items' field `dateLastPurchased` would be automatically set to the current date whenever a list was opened in the app even without buying them. The fix was done using an additional condition to update the item in the database. 
2. On an attempt to mark an item with `dateLastPurchased` older than 24 hours as purchased would result in the immediate automatic re-render and removal of the check mark by the app itself. This was fixed by adding an additional state `boxChecked`, which keeps track if the user changes the `isChecked` status manually.

The biggest challenges of this week for us were the vague description of the assignment, which required additional help from @lindseyindev to understand what should be changed and is expected as a result, as well as to form a strategy on tackling this issue, as well as fighting bugs in logic for updating data of items on their purchase.

Note: we as a team need to additionally work on the logic of manual unchecking, because right now unchecking an item affects `dateLastPurchased`, `dateNextPurchased` and `previousEstimate`. This can be possibly achieved by storing previous values in the database and using them when the user unchecks an item.

## Related Issue

Closes #10 

## Acceptance Criteria

- [x] A `getDaysBetweenDates` function is exported from `utils/dates.js`  and imported into `api/firebase.js`
  - [x] This function takes two JavaScript Dates and return the number of days that have passed between them
- [x] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
  - [x] `dateNextPurchased` is saved as **a date**, not a number

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
| ✓  | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
`dateNextPurchased` calculated the future date according to what checkbox you picked (soon, kind of soon, not soon) when you first added the item using a `getFutureDate()`. 
<img width="693" alt="Screen Shot 2022-08-06 at 10 10 14 PM" src="https://user-images.githubusercontent.com/90009901/183250291-f49ac413-b174-4909-9739-50305f241f72.png">

### After

Now, the data in firebase for `dateNextPurchased` is updated according to how long it has been between the date you last purchased an item and the moment you purchased it in the present. 

_Before purchase_: 

<img width="391" alt="Screen Shot 2022-08-06 at 10 07 25 PM" src="https://user-images.githubusercontent.com/90009901/183250361-c44fe0da-09de-4d43-b45d-82c78388f5c1.png">

<img width="368" alt="Screen Shot 2022-08-06 at 10 07 35 PM" src="https://user-images.githubusercontent.com/90009901/183250354-de78a849-3e72-4f70-b24e-4eaccf06e59d.png">

_After purchase_:

<img width="365" alt="Screen Shot 2022-08-06 at 10 07 38 PM" src="https://user-images.githubusercontent.com/90009901/183250402-01d01762-fbd3-4893-82dd-06be7524beb9.png">

<img width="368" alt="Screen Shot 2022-08-06 at 10 07 21 PM" src="https://user-images.githubusercontent.com/90009901/183250409-d2474ee2-7513-479b-a98f-00cfcb99b1d3.png">

## Testing Steps / QA Criteria
1. Checkout `NZ-MK-estimate-next-purchase-date` on your local computer and npm start.
2. Open firebase and click on the list name that your local device will be using to test this feature.
3. Add an item and choose one of the time estimates, and check in your firebase database. You should see the correct date estimated according to what choice of initial time estimate you chose (soon = 7 days, kind of soon = 14 days, not soon = 30 days). `dateLastPurchased` should be null. `previousEstimate` should be the number in correspondence to your initial time estimate (7, 14, or 30). 
4. Go to your List and click on the checkbox of the item you just added. In your firebase, it should have updated to populate `dateLastPurchased` to today's date, and `dateNextPurchased` to tomorrow's date, and `previousEstimate` to 1. This is because it has only been < 1 day since you last "purchased" your item.
5. To test for further accuracy, you can change the `dateLastPurchased` and `dateCreated` on firebase directly to see if `previousEstimate` and `dateNextPurchased` updates accurately (must be a timeline that works for ex, `dateCreated` has to be a date that comes before `dateLastPurchased`)
