### PR TITLE
New date fields to improve date re-calculation when items are updated

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -134,6 +134,14 @@ export async function updateItemBack(listId, itemData) {
 	});
 }
 
+export async function updateItemCheckedStatus(listId, itemData) {
+	const itemRef = doc(db, listId, itemData.id);
+
+	await updateDoc(itemRef, {
+		isChecked: itemData.isChecked,
+	});
+}
+
 export async function deleteItem(listId, itemData) {
 	await deleteDoc(doc(db, listId, itemData.id));
 }

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -79,13 +79,16 @@ export async function addItem(listId, { itemName, daysUntilNextPurchase }) {
 		dateCreated: new Date(),
 		// NOTE: This is null because the item has just been created.
 		// We'll put a Date here when the item is purchased!
+		previousDateLastPurchased: null,
 		dateLastPurchased: null,
+		previousDateNextPurchased: null,
 		dateNextPurchased: getFutureDate(daysUntilNextPurchase),
 		// This property will be used when we build out more of our UI.
 		isChecked: false,
 		name: itemName,
 		totalPurchases: 0,
-		previousEstimate: parseInt(daysUntilNextPurchase),
+		previousEstimate: null,
+		currentEstimate: parseInt(daysUntilNextPurchase),
 	});
 }
 
@@ -99,10 +102,10 @@ export async function updateItem(listId, itemData) {
 		: (daysSinceLastTransaction = getDaysBetweenDates(itemData.dateCreated));
 
 	// this line with "let previousEstimate = parseInt .." can be removed if the database is reset. This line is required for converting old time frame entriies to numbers.
-	let previousEstimate = parseInt(itemData.previousEstimate);
+	let currentEstimate = parseInt(itemData.previousEstimate);
 
 	let newTimeEstimate = calculateEstimate(
-		previousEstimate,
+		currentEstimate,
 		daysSinceLastTransaction,
 		itemData.totalPurchases,
 	);
@@ -110,9 +113,24 @@ export async function updateItem(listId, itemData) {
 	await updateDoc(itemRef, {
 		totalPurchases: itemData.totalPurchases,
 		isChecked: itemData.isChecked,
+		previousDateLastPurchased: itemData.dateLastPurchased,
 		dateLastPurchased: new Date(),
+		previousDateNextPurchased: itemData.dateNextPurchased,
 		dateNextPurchased: getFutureDate(newTimeEstimate),
-		previousEstimate: newTimeEstimate,
+		previousEstimate: itemData.currentEstimate,
+		currentEstimate: newTimeEstimate,
+	});
+}
+
+export async function updateItemBack(listId, itemData) {
+	const itemRef = doc(db, listId, itemData.id);
+
+	await updateDoc(itemRef, {
+		totalPurchases: itemData.totalPurchases,
+		isChecked: itemData.isChecked,
+		dateLastPurchased: itemData.previousDateLastPurchased,
+		dateNextPurchased: itemData.previousDateNextPurchased,
+		currentEstimate: itemData.previousEstimate,
 	});
 }
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,6 +1,11 @@
 import './ListItem.css';
 import { useState, useEffect } from 'react';
-import { updateItem, deleteItem, updateItemBack } from '../api';
+import {
+	updateItem,
+	deleteItem,
+	updateItemBack,
+	updateItemCheckedStatus,
+} from '../api';
 const one_day_in_ms = 24 * 60 * 60 * 1000;
 // const one_day_in_ms = 60 * 2 * 1000; // 120 seconds for testing the reset timeframe
 
@@ -40,14 +45,14 @@ export function ListItem({ item, listToken }) {
 			boxChecked === true
 		) {
 			item.isChecked = isPurchased;
-			updateItem(listToken, item);
+			updateItemCheckedStatus(listToken, item);
 		} else if (
 			timeElapsed > one_day_in_ms &&
 			item.isChecked === true &&
 			boxChecked === false
 		) {
 			item.isChecked = false;
-			updateItem(listToken, item);
+			updateItemCheckedStatus(listToken, item);
 		}
 	});
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,6 +1,6 @@
 import './ListItem.css';
 import { useState, useEffect } from 'react';
-import { updateItem, deleteItem } from '../api';
+import { updateItem, deleteItem, updateItemBack } from '../api';
 const one_day_in_ms = 24 * 60 * 60 * 1000;
 // const one_day_in_ms = 60 * 2 * 1000; // 120 seconds for testing the reset timeframe
 
@@ -26,7 +26,7 @@ export function ListItem({ item, listToken }) {
 				item.totalPurchases--;
 				item.isChecked = false;
 				setBoxChecked(false);
-				await updateItem(listToken, item);
+				await updateItemBack(listToken, item);
 			}
 		} catch (error) {
 			console.log('error', error);

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -36,34 +36,34 @@ export function List({ data, listToken, loading }) {
 	}
 
 	//4 groups, within each group
-	//order items by previousEstimate within the group
+	//order items by currentEstimate within the group
 	const groups = [
 		{
 			timeFrame: 'Soon',
 			subLabel: '7 days or less',
 			filteredData: (item) => {
-				return item.previousEstimate <= 7;
+				return item.currentEstimate <= 7;
 			},
 		},
 		{
 			timeFrame: 'Kind of soon',
 			subLabel: 'Between 7 and 30 days',
 			filteredData: (item) => {
-				return item.previousEstimate > 7 && item.previousEstimate < 30;
+				return item.currentEstimate > 7 && item.currentEstimate < 30;
 			},
 		},
 		{
 			timeFrame: 'Not that soon',
 			subLabel: 'Between 30 and 60 days',
 			filteredData: (item) => {
-				return item.previousEstimate >= 30 && item.previousEstimate < 60;
+				return item.currentEstimate >= 30 && item.currentEstimate < 60;
 			},
 		},
 		{
 			timeFrame: 'Inactive',
 			subLabel: '60 days or more',
 			filteredData: (item) => {
-				return item.previousEstimate >= 60;
+				return item.currentEstimate >= 60;
 			},
 		},
 	];


### PR DESCRIPTION
## Description

This PR is aimed at enhancing and securing the date saving logic for new items. In the current version when items are unchecked (marked as not purchased), the date of the next purchase is re-calculated with today's date and other dates are re-calculated because of it. I have renamed `previousEstimate` to `currentEstimated` to reflect its purpose and added fields `previousEstimate`, `previousDateNextPurchased` and `previousDateLastPurchased` to store the history of previous purchases.

When item is checked as purchased by mistake and then unchecked within less 24 hours, `dateNextPurchased`, `dateLastPurchased` and `currentEstimate` are reset to their old values stored in the recently added fields with the prefix `previous-` using the function `updateItemBack`. This means that unchecking no longer affects other date calculations and dates are finally reliable.

I also added an additional function `updateItemCheckedStatus` to update only the `isChecked` status of an item in the database when 24 hours since the moment of the purchase have past and the item automatically unchecks itself. Before they would automatically uncheck and cause a chain of date re-calculations because the whole item was set to be updated.

### Explanation in two slides ###

![Untitled Jam 1](https://user-images.githubusercontent.com/63440229/185293012-d41f75d5-627f-44bf-9c8c-e958b343a122.png)
![Untitled Jam 2](https://user-images.githubusercontent.com/63440229/185293015-ef77d0e5-12f7-4082-9daf-8d032457efb9.png)

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

Closes #24 

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|   ✓   | :bug: Bug fix              |
|  ✓  | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Testing Steps / QA Criteria

1. `git checkout NZ-better-time-related-logic`
2. Add a new item to your list
3. Go to Firestore and find the list with this item
4. Make a snapshot of the document with the item data
5. Check and then uncheck the item in the app
6. Compare the snapshot and the current state of the item in the database. dateNextPurchased, dateLastPurchased, currentEstimate should be the same as in the snapshot

Note: I have cleaned the database, so that there are no items with the older set of values to avoid any conflict when updating them.

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
