### PR TITLE
removed Toast component from List

### DIFF
--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -80,7 +80,9 @@ export function List({ data, listToken, loading, confirmLogOut }) {
 	];
 
 	const compareDuplicate = (itemNameToCompare) => {
-		const match = data.find((item) => itemNameToCompare === item.name);
+		const match = data.find(
+			(item) => itemNameToCompare.toLowerCase() === item.name.toLowerCase(),
+		);
 
 		if (match) {
 			toast(

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -2,7 +2,6 @@ import './List.css';
 import { ListItem } from '../components';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Toaster } from 'react-hot-toast';
 import redblinky from '../../src/assets/red-blinky.png';
 import pinkblinky from '../../src/assets/pink-blinky.png';
 import yellowblinky from '../../src/assets/yellow-blinky.png';
@@ -95,7 +94,6 @@ export function List({ data, listToken, loading, confirmLogOut }) {
 
 	return (
 		<div className="list-container">
-			<Toaster />
 			{loading ? (
 				<p>Your list is loading...</p>
 			) : (


### PR DESCRIPTION
## Description

This PR is a hot fix for the edit item functionality. There was a <Toaster /> component in ListItem.jsx which I removed. This was causing an issue with the compareDuplicate function and was allowing items to be added despite already being on the list. I replaced the <Toaster /> component in Index.js which gives the entire app access to toast. 

## Related Issue

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|    | :sparkles: New feature     |
|  ✓   | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Testing Steps / QA Criteria
`git checkout main` then `git pull`
`git checkout TR-edit-item-and-toast-hot-fix`
Add items if none already added. 
Attempt to edit an item and rename it the same thing as something already on the list. 
Notice the toast error message. 
